### PR TITLE
feat: load static CSVs from ../../data

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -6,7 +6,6 @@
 .ef-controls input[type="number"] { width:100%; padding:8px; border:1px solid #d1d5db; border-radius:8px; }
 .ef-btn { display:inline-block; margin-right:8px; margin-top:6px; padding:8px 12px; border-radius:10px; border:1px solid #d1d5db; background:#f9fafb; cursor:pointer; }
 .ef-btn.primary { background:#111827; color:#fff; border-color:#111827; }
-.ef-upload { border:2px dashed #cbd5e1; border-radius:12px; padding:12px; text-align:center; }
 .ef-legend { font-size:12px; color:#374151; margin-top:8px; }
 .ef-badge { display:inline-block; padding:2px 8px; border-radius:999px; background:#eef2ff; color:#3730a3; margin-right:8px; }
 svg text { font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", "Apple Color Emoji", "Segoe UI Emoji"; }

--- a/src/html/app.html
+++ b/src/html/app.html
@@ -13,20 +13,8 @@
   <div class="ef-card ef-controls">
     <h3>Inputs</h3>
 
-    <div class="row ef-upload">
-      <div><strong>Upload CSVs (same format as your desktop app)</strong></div>
-      <div style="margin-top:8px">
-        <label>Expected Returns:</label>
-        <input id="ef-returns" type="file" accept=".csv" />
-      </div>
-      <div style="margin-top:8px">
-        <label>Volatilities:</label>
-        <input id="ef-vols" type="file" accept=".csv" />
-      </div>
-      <div style="margin-top:8px">
-        <label>Correlations:</label>
-        <input id="ef-corr" type="file" accept=".csv" />
-      </div>
+    <div class="row">
+      <div><strong>Using built-in sample data from ../../data</strong></div>
     </div>
 
     <div class="row">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,10 +1,33 @@
-// test edit
 import * as d3 from "d3";
 import Papa from "papaparse";
 
+const DATA_BASE = "../../data";
+
+async function fetchCsv(path) {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error(`Failed to fetch ${path}: ${res.status}`);
+  const text = await res.text();
+  const parsed = Papa.parse(text, { header: false, dynamicTyping: true });
+  return parsed.data;
+}
+
+async function loadStaticData() {
+  const [retRows, volRows, corrRows] = await Promise.all([
+    fetchCsv(`${DATA_BASE}/Asset_Returns.csv`),
+    fetchCsv(`${DATA_BASE}/Asset_Volatilities.csv`),
+    fetchCsv(`${DATA_BASE}/Asset_Correlations.csv`),
+  ]);
+
+  const assets = retRows.slice(1).map(r => String(r[0]));
+  const meanReturns = retRows.slice(1).map(r => Number(r[1]));
+  const vols = volRows.slice(1).map(r => Number(r[1]));
+  const corr = corrRows.slice(1).map(row => row.slice(1).map(Number));
+  return { assets, meanReturns, vols, corr };
+}
+
 /**
  * Web MVP of your PyQt5 app:
- * - Upload three CSVs: Asset_Returns.csv, Asset_Volatilities.csv, Asset_Correlations.csv
+ * - Uses built-in CSVs: Asset_Returns.csv, Asset_Volatilities.csv, Asset_Correlations.csv
  * - Compute random portfolios (approximate frontier), MVP, Max-Sharpe
  * - Add user portfolio by weights and custom R/V points
  * - Draw interactive scatter + frontier line
@@ -89,29 +112,12 @@ function qs(sel){ return document.querySelector(sel); }
 
 function setup() {
   // wire inputs
-  const returnsInput = qs("#ef-returns");
-  const volsInput = qs("#ef-vols");
-  const corrInput = qs("#ef-corr");
-  const rfInput = qs("#ef-rf");
-  const simsInput = qs("#ef-sims");
   const runBtn = qs("#ef-run");
   const eqBtn = qs("#ef-eq");
   const addWeightsBtn = qs("#ef-add-weights");
   const clearWeightsBtn = qs("#ef-clear-weights");
   const addRVBtn = qs("#ef-add-rv");
   const clearRVBtn = qs("#ef-clear-rv");
-
-  // parse CSVs
-  function parseCsv(file) {
-    return new Promise((resolve, reject) => {
-      Papa.parse(file, {
-        header: false,
-        dynamicTyping: true,
-        complete: (res) => resolve(res.data),
-        error: reject
-      });
-    });
-  }
 
   // Equal-weight helper
   eqBtn.addEventListener("click", () => {
@@ -132,39 +138,17 @@ function setup() {
   });
 
   runBtn.addEventListener("click", async () => {
-    if (!returnsInput.files[0] || !volsInput.files[0] || !corrInput.files[0]) {
-      alert("Please select all three CSVs first.");
-      return;
-    }
-    // Load data
-    const [retRows, volRows, corrRows] = await Promise.all([
-      parseCsv(returnsInput.files[0]),
-      parseCsv(volsInput.files[0]),
-      parseCsv(corrInput.files[0])
-    ]);
-
-    // Expect: first column = Asset Name, second column = value
-    const assets = retRows.slice(1).map(r => String(r[0]));
-    const meanReturns = retRows.slice(1).map(r => Number(r[1])); // already decimals in your CSV
-    const vols = volRows.slice(1).map(r => Number(r[1]));        // decimals
-    // Correlations: square matrix with header row/col
-    const corr = corrRows.slice(1).map(row => row.slice(1).map(Number));
-
-    // Basic validation like the Py app
-    if (assets.length !== vols.length || corr.length !== assets.length) {
-      alert("Assets / Vols / Corr dimensions don’t match.");
-      return;
-    }
-
+    const { assets, meanReturns, vols, corr } = await loadStaticData();
+    console.log("Loaded data:", assets.length, meanReturns.length, vols.length, corr.length);
     state.assets = assets;
     state.meanReturns = meanReturns;
     state.vols = vols;
     state.corr = corr;
     state.cov = computeCov(vols, corr);
-    state.rf = clamp(Number(rfInput.value) / 100, 0, 1);
-    const sims = clamp(parseInt(simsInput.value || "50000", 10), 1000, 200000);
+    state.rf = clamp(Number(qs("#ef-rf").value) / 100, 0, 1);
+    const sims = clamp(parseInt(qs("#ef-sims").value || "50000", 10), 1000, 200000);
 
-    // Generate random portfolios
+    // generate cloud exactly as before...
     const cloud = [];
     for (let i = 0; i < sims; i++) {
       let w = Array.from({ length: assets.length }, () => Math.random());
@@ -176,9 +160,8 @@ function setup() {
     }
     state.cloud = cloud;
 
-    draw(); // initial chart
-    // Build dynamic weight inputs (if not present)
-    if (!qs("#ef-weights input")) eqBtn.click();
+    draw();
+    if (!qs("#ef-weights input")) qs("#ef-eq").click();
   });
 
   addWeightsBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- load sample CSVs from `../../data` instead of requiring uploads
- trim HTML controls and CSS for file uploads

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc03da69d88326878e451f8d05b36a