### PR TITLE
Copy data folder into dist during build

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,4 +1,5 @@
 import { build } from "esbuild";
+import { cp } from "fs/promises";
 
 await build({
   entryPoints: ["src/js/app.js", "src/css/app.css"],
@@ -8,4 +9,9 @@ await build({
   sourcemap: false,
   loader: { ".css": "css" }
 });
+
+// Copy static CSV data files into the build output so they're available
+// when the site is deployed (e.g. GitHub Pages expects everything under `dist`).
+await cp("data", "dist/data", { recursive: true });
+
 console.log("Built to /dist");


### PR DESCRIPTION
## Summary
- ensure CSV data files are copied into the `dist` directory during builds so GitHub Pages can access them

## Testing
- `npm run build`
- `curl -Lk https://danjra.github.io/wp-efficient-frontier/data/Asset_Returns.csv` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc406159e88326b5faba3d57399e3e