### PR TITLE
Use WordPress-hosted sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Web version of efficient frontier visualization.
 
+## Data Source
+The application pulls its sample CSV data from the WordPress media library:
+
+- https://capitalogic.co/wp-content/uploads/2025/09/Asset_Returns.csv
+- https://capitalogic.co/wp-content/uploads/2025/09/Asset_Volatilities.csv
+- https://capitalogic.co/wp-content/uploads/2025/09/Asset_Correlations.csv
+
 ## Build
 ```bash
 npm install

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,5 +1,4 @@
 import { build } from "esbuild";
-import { cp } from "fs/promises";
 
 await build({
   entryPoints: ["src/js/app.js", "src/css/app.css"],
@@ -9,9 +8,5 @@ await build({
   sourcemap: false,
   loader: { ".css": "css" }
 });
-
-// Copy static CSV data files into the build output so they're available
-// when the site is deployed (e.g. GitHub Pages expects everything under `dist`).
-await cp("data", "dist/data", { recursive: true });
 
 console.log("Built to /dist");

--- a/src/html/app.html
+++ b/src/html/app.html
@@ -14,7 +14,7 @@
     <h3>Inputs</h3>
 
     <div class="row">
-      <div><strong>Using built-in sample data from ../../data</strong></div>
+      <div><strong>Sample data loaded from the WordPress media library</strong></div>
     </div>
 
     <div class="row">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,19 +1,15 @@
 import * as d3 from "d3";
 import Papa from "papaparse";
 
-// Locate the CSV sample data relative to the compiled script. When bundled by
-// esbuild the runtime file may live at `dist/js/app.js` while the CSV files
-// remain in `data/` at the project root. When embedded directly the script is
-// typically served from `/js/app.js`. Detect the former case and adjust the
-// directory traversal accordingly so the data folder resolves correctly in both
-// scenarios.
-function resolveDataBase() {
-  const src = document.currentScript?.src || "";
-  return src.includes("/dist/")
-    ? new URL("../../data", src).href
-    : new URL("../data", src).href;
-}
-const DATA_BASE = resolveDataBase();
+// Static CSV files hosted in the WordPress media library.
+const DATA_URLS = {
+  returns:
+    "https://capitalogic.co/wp-content/uploads/2025/09/Asset_Returns.csv",
+  vols:
+    "https://capitalogic.co/wp-content/uploads/2025/09/Asset_Volatilities.csv",
+  corr:
+    "https://capitalogic.co/wp-content/uploads/2025/09/Asset_Correlations.csv",
+};
 
 async function fetchCsv(path) {
   const res = await fetch(path);
@@ -25,9 +21,9 @@ async function fetchCsv(path) {
 
 async function loadStaticData() {
   const [retRows, volRows, corrRows] = await Promise.all([
-    fetchCsv(`${DATA_BASE}/Asset_Returns.csv`),
-    fetchCsv(`${DATA_BASE}/Asset_Volatilities.csv`),
-    fetchCsv(`${DATA_BASE}/Asset_Correlations.csv`),
+    fetchCsv(DATA_URLS.returns),
+    fetchCsv(DATA_URLS.vols),
+    fetchCsv(DATA_URLS.corr),
   ]);
 
   const assets = retRows.slice(1).map(r => String(r[0]));
@@ -40,7 +36,7 @@ async function loadStaticData() {
 
 /**
  * Web MVP of your PyQt5 app:
- * - Uses built-in CSVs: Asset_Returns.csv, Asset_Volatilities.csv, Asset_Correlations.csv
+ * - Loads CSVs from the WordPress media library
  * - Compute random portfolios (approximate frontier), MVP, Max-Sharpe
  * - Add user portfolio by weights and custom R/V points
  * - Draw interactive scatter + frontier line


### PR DESCRIPTION
## Summary
- Load sample CSVs from WordPress media library instead of local files
- Update UI copy and documentation to reflect remote data source
- Simplify build config by removing unused data-copy step

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc42f06e808326ba3746581624d289